### PR TITLE
Add `-t` option to support customizing message template

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![version](https://img.shields.io/npm/v/prepare-commit-msg-angular.svg?style=flat-square)](http://npm.im/prepare-commit-msg-angular)
 [![MIT License](https://img.shields.io/npm/l/prepare-commit-msg-angular.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 
+## Basic Usage
 This provides you a binary that you can use as a githook to prepare a commit message following Angular guidelines and display documentation about it.
 I recommend
 [ghooks](http://npm.im/ghooks) :
@@ -15,3 +16,17 @@ I recommend
 ```
 
 To use with [validate-commit-msg](https://github.com/kentcdodds/validate-commit-msg).
+
+## Message Template
+By default, the `default.tpl` will be shown in your git editor.
+
+You can also specify your preferred message template by `-t` option.
+
+e.g.
+```
+    "config": {
+        "ghooks": {
+            "prepare-commit-msg": "prepare-commit-msg-angular $2 $3 -t tpl_file_path"
+        }
+    }
+```

--- a/default.tpl
+++ b/default.tpl
@@ -1,0 +1,25 @@
+# <type>(<scope>): <subject>
+# <BLANK LINE>
+# <body>
+# <BLANK LINE>
+# <footer>
+#---
+# TYPE must be one of the following:
+# - feat: A new feature (will appear in CHANGELOG)
+# - fix: A bug fix (will appear in CHANGELOG)
+# - docs: Documentation only changes
+# - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+# - refactor: A code change that neither fixes a bug nor adds a feature
+# - perf: A code change that improves performance (will appear in CHANGELOG)
+# - test: Adding missing tests
+# - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
+#
+# SCOPE could be anything specifying place of the commit change.
+# For example $location, $browser, $compile, $rootScope, ngHref, ngClick, ngView, etc...
+#
+# SUBJECT contains succinct description of the change:
+# - use the imperative, present tense: "change" not "changed" nor "changes"
+# - do not capitalize first letter
+# - no dot (.) at the end
+#---
+# https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var commitMsgFile = process.argv[2] || './.git/COMMIT_EDITMSG';
 var isNewCommit = (process.argv[3] === 'undefined');
 
 var maxCharsLine = '#⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴';
-var scissorsLine = '# ---------- Message Formatting Convention ----------';
+var scissorsLine = '# ------------------------ >8 ------------------------';
 
 program
   .option('-t, --template [file path]', 'Set file location of template for git commit message', '')

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var msgTplFile = !program.template ? './default.tpl' : program.template;
 try {
   fs.accessSync(msgTplFile, fs.R_OK)
 } catch (err) {
-  console.error(consoleError('Invalid path for template file: ' + msgTplFile));
+  console.error(consoleError('Invalid path: ' + msgTplFile + '\n\r' + err.toString()));
   process.exit(1);
 }
 

--- a/index.js
+++ b/index.js
@@ -4,38 +4,32 @@
 
 var fs = require('fs');
 var execSync = require('child_process').execSync;
+var program = require('commander');
+var clc = require('cli-color');
+var consoleError = clc.red.bold;
 
 var commitMsgFile = process.argv[2] || './.git/COMMIT_EDITMSG';
 var isNewCommit = (process.argv[3] === 'undefined');
 
 var maxCharsLine = '#⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴⎴';
-var scissorsLine = '# ------------------------ >8 ------------------------';
-var doc = `${scissorsLine}
-# <type>(<scope>): <subject>
-# <BLANK LINE>
-# <body>
-# <BLANK LINE>
-# <footer>
-#---
-# TYPE must be one of the following:
-# - feat: A new feature (will appear in CHANGELOG)
-# - fix: A bug fix (will appear in CHANGELOG)
-# - docs: Documentation only changes
-# - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-# - refactor: A code change that neither fixes a bug nor adds a feature
-# - perf: A code change that improves performance (will appear in CHANGELOG)
-# - test: Adding missing tests
-# - chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-#
-# SCOPE could be anything specifying place of the commit change.
-# For example $location, $browser, $compile, $rootScope, ngHref, ngClick, ngView, etc...
-#
-# SUBJECT contains succinct description of the change:
-# - use the imperative, present tense: "change" not "changed" nor "changes"
-# - do not capitalize first letter
-# - no dot (.) at the end
-#---
-# https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md
+var scissorsLine = '# ---------- Message Formatting Convention ----------';
+
+program
+  .option('-t, --template [file path]', 'Set file location of template for git commit message', '')
+  .parse(process.argv);
+var msgTplFile = !program.template ? './default.tpl' : program.template;
+try {
+  fs.accessSync(msgTplFile, fs.R_OK)
+} catch (err) {
+  console.error(consoleError('Invalid path for template file: ' + msgTplFile));
+  process.exit(1);
+}
+
+var msgTpl = fs.readFileSync(msgTplFile).toString();
+
+var doc = `
+${scissorsLine}
+${msgTpl}
 `;
 
 function getPrefilledMessage() {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "0.2.0",
   "main": "index.js",
   "bin": "index.js",
-  "engines" : {
-    "node" : ">=4.0"
+  "engines": {
+    "node": ">=4.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "cli-color": "^1.1.0",
+    "commander": "^2.9.0"
+  },
   "devDependencies": {
     "ghooks": "^1.0.1",
     "validate-commit-msg": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepare-commit-msg-angular",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "bin": "index.js",
   "engines": {


### PR DESCRIPTION
With this, user can specify a preferred message template which will be shown in the git editor.
